### PR TITLE
Improvements and fixes to #26

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ FROM python:3.11-slim as build
 
 # install mysqlclient requirements
 RUN \
-	--mount=type=cache,target=/var/cache/apt --mount=type=cache,target=/var/lib/apt \
+	--mount=type=cache,target=/var/cache/apt,sharing=locked --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
 	rm -f /etc/apt/apt.conf.d/docker-clean; \
 	echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache; \
 	apt-get update && \
@@ -37,10 +37,9 @@ RUN \
 
 FROM python:3.11-slim as deploy
 
-# install mysqlclient without build-essential (this copy will work only with --no-cache)
-COPY --from=build /var/lib/apt/lists /var/lib/apt/lists
+# install mysqlclient without build-essential
 RUN \
-	--mount=type=cache,target=/var/cache/apt --mount=type=cache,target=/var/lib/apt \
+	--mount=type=cache,target=/var/cache/apt,sharing=locked --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
 	rm -f /etc/apt/apt.conf.d/docker-clean; \
 	echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache; \
 	apt-get update && \

--- a/compose.yaml
+++ b/compose.yaml
@@ -97,6 +97,8 @@ services:
     stop_signal: SIGQUIT
     depends_on:
       - website-prod
+    env_file:
+      - prod/config.env
     environment:
       - NGINX_ENTRYPOINT_LOCAL_RESOLVERS=1
     volumes:
@@ -116,7 +118,7 @@ services:
       context: prod/mail/postfix
       dockerfile: Dockerfile
     container_name: postfix
-    depends_on: 
+    depends_on:
       - website-prod
     env_file:
       - prod/mail/config.env
@@ -136,7 +138,7 @@ services:
       context: prod/mail/opendkim
       dockerfile: Dockerfile
     container_name: opendkim
-    depends_on: 
+    depends_on:
       - website-prod
     env_file:
       - prod/mail/config.env

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -12,7 +12,7 @@ FROM python:3.11-slim as build
 
 # install mysqlclient requirements
 RUN \
-	--mount=type=cache,target=/var/cache/apt --mount=type=cache,target=/var/lib/apt \
+	--mount=type=cache,target=/var/cache/apt,sharing=locked --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
 	rm -f /etc/apt/apt.conf.d/docker-clean; \
 	echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache; \
 	apt-get update && \
@@ -37,10 +37,9 @@ RUN \
 
 FROM python:3.11-slim as deploy
 
-# install mysqlclient without build-essential (this copy will work only with --no-cache)
-COPY --from=build /var/lib/apt/lists /var/lib/apt/lists
+# install mysqlclient without build-essential
 RUN \
-	--mount=type=cache,target=/var/cache/apt --mount=type=cache,target=/var/lib/apt \
+	--mount=type=cache,target=/var/cache/apt,sharing=locked --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
 	rm -f /etc/apt/apt.conf.d/docker-clean; \
 	echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache; \
 	apt-get update && \

--- a/prod/mail/opendkim/Dockerfile
+++ b/prod/mail/opendkim/Dockerfile
@@ -2,7 +2,9 @@
 FROM debian:stable-slim as builder
 
 RUN \
-	--mount=type=cache,target=/var/cache/apt,sharing=locked --mount=type=cache,target=/var/lib/apt,sharing=locked \
+	--mount=type=cache,target=/var/cache/apt,sharing=locked --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
+	rm -f /etc/apt/apt.conf.d/docker-clean; \
+	echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache; \
 	apt-get update && \
 	apt-get install --no-install-recommends -y libc6-dev gcc ca-certificates wget unzip
 
@@ -16,7 +18,7 @@ RUN wget https://github.com/ossobv/syslog2stdout/archive/142793f15169fa01c0e1249
 FROM debian:stable-slim as deploy
 
 RUN \
-	--mount=type=cache,target=/var/cache/apt,sharing=locked --mount=type=cache,target=/var/lib/apt,sharing=locked \
+	--mount=type=cache,target=/var/cache/apt,sharing=locked --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
 	rm -f /etc/apt/apt.conf.d/docker-clean; \
 	echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache; \
 	apt-get update && \

--- a/prod/mail/postfix/Dockerfile
+++ b/prod/mail/postfix/Dockerfile
@@ -2,7 +2,7 @@
 FROM debian:stable-slim
 
 RUN \
-	--mount=type=cache,target=/var/cache/apt,sharing=locked --mount=type=cache,target=/var/lib/apt,sharing=locked \
+	--mount=type=cache,target=/var/cache/apt,sharing=locked --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
 	rm -f /etc/apt/apt.conf.d/docker-clean; \
 	echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache; \
 	apt-get update && \

--- a/prod/nginx/templates/default.conf.template
+++ b/prod/nginx/templates/default.conf.template
@@ -5,7 +5,18 @@ server {
     listen [::]:80 default_server;
 
     location / {
-        return 301 https://$host$request_uri;
+        return 301 https://${DOMAIN}$request_uri;
+    }
+}
+
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+
+    include conf.d/ssl_common.conf;
+
+    location / {
+        return 301 https://${DOMAIN}$request_uri;
     }
 }
 
@@ -53,34 +64,11 @@ server {
     listen [::]:443 quic reuseport;
     listen [::]:443 ssl;
 
+    server_name ${DOMAIN};
+
     http2 on;
 
-    ssl_certificate /run/secrets/fullchain;
-    ssl_certificate_key /run/secrets/privkey;
-    ssl_session_timeout 1d;
-    ssl_session_cache shared:MozSSL:10m;  # about 40000 sessions
-    ssl_session_tickets off;
-
-    # https://ssl-config.mozilla.org/ffdhe2048.txt (RFC7919 A.1)
-    ssl_dhparam ffdhe2048.txt;
-
-    # intermediate configuration
-    ssl_protocols TLSv1.2 TLSv1.3;
-    ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-CHACHA20-POLY1305;
-    ssl_prefer_server_ciphers off;
-
-    # HSTS (ngx_http_headers_module is required) (63072000 seconds)
-    add_header Strict-Transport-Security "max-age=63072000" always;
-
-    # OCSP stapling
-    ssl_stapling on;
-    ssl_stapling_verify on;
-
-    # verify chain of trust of OCSP response using Root CA and Intermediate certs
-    ssl_trusted_certificate /run/secrets/chain;
-
-    # entrypoint script will populate it if $NGINX_ENTRYPOINT_LOCAL_RESOLVERS is set
-    resolver ${NGINX_LOCAL_RESOLVERS};
+    include conf.d/ssl_common.conf;
 
     # required for browsers to direct them into quic port
     add_header Alt-Svc 'h3=":443"; ma=86400';

--- a/prod/nginx/templates/ssl_common.conf.template
+++ b/prod/nginx/templates/ssl_common.conf.template
@@ -1,0 +1,26 @@
+ssl_certificate /run/secrets/fullchain;
+ssl_certificate_key /run/secrets/privkey;
+ssl_session_timeout 1d;
+ssl_session_cache shared:MozSSL:10m;  # about 40000 sessions
+ssl_session_tickets off;
+
+# https://ssl-config.mozilla.org/ffdhe2048.txt (RFC7919 A.1)
+ssl_dhparam ffdhe2048.txt;
+
+# intermediate configuration
+ssl_protocols TLSv1.2 TLSv1.3;
+ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-CHACHA20-POLY1305;
+ssl_prefer_server_ciphers off;
+
+# HSTS (ngx_http_headers_module is required) (63072000 seconds)
+add_header Strict-Transport-Security "max-age=63072000" always;
+
+# OCSP stapling
+ssl_stapling on;
+ssl_stapling_verify on;
+
+# verify chain of trust of OCSP response using Root CA and Intermediate certs
+ssl_trusted_certificate /run/secrets/chain;
+
+# entrypoint script will populate it if $NGINX_ENTRYPOINT_LOCAL_RESOLVERS is set
+resolver ${NGINX_LOCAL_RESOLVERS};

--- a/website/__init__.py
+++ b/website/__init__.py
@@ -13,7 +13,6 @@ from werkzeug.middleware.proxy_fix import ProxyFix
 from .secrets_manager import *
 
 production = getenv("FLASK_ENV") == "production"
-domain = getenv("DOMAIN", "orp.testing" if production else "localhost")
 
 db = SQLAlchemy()
 migrate = Migrate()
@@ -51,8 +50,9 @@ def create_app():
     app.config["SECRET_KEY"] = SECRET_KEY
     app.config["RECAPTCHA_PUBLIC_KEY"] = RECAPTCHA_PUBLIC_KEY
     app.config["RECAPTCHA_PRIVATE_KEY"] = RECAPTCHA_PRIVATE_KEY
-    app.config["SERVER_NAME"] = domain if production else f"{domain}:5004"
     app.config["MAILERLITE_API_KEY"] = MAILERLITE_API_KEY
+    if production:
+        app.config["SERVER_NAME"] = getenv("DOMAIN", "orp.testing")
 
     if getenv("TRUSTED_PROXIES", "0") == "1":
         app.wsgi_app = ProxyFix(app.wsgi_app, x_for=1, x_proto=1, x_host=1, x_prefix=1)

--- a/website/auth.py
+++ b/website/auth.py
@@ -87,22 +87,21 @@ def sign_up():
                         ),
                     )
                     db.session.add(new_user_data)
-                    if production:
-                        db.session.flush()
-                        activation_token = secrets.token_bytes(32)
-                        confirmation_url = url_for(
-                            ".confirm_email",
-                            _scheme="https",
-                            _external=True,
-                            token_enc=base64.urlsafe_b64encode(activation_token),
-                        )
-                        saved_token = EmailToken(
-                            token=activation_token,
-                            token_type=TokenType.mail_confirmation,
-                            user_id=new_user_data.id,
-                        )
-                        db.session.add(saved_token)
-                        send_confirmation_mail(username, email, confirmation_url)
+                    db.session.flush()
+                    activation_token = secrets.token_bytes(32)
+                    confirmation_url = url_for(
+                        ".confirm_email",
+                        _scheme="https",
+                        _external=True,
+                        token_enc=base64.urlsafe_b64encode(activation_token),
+                    )
+                    saved_token = EmailToken(
+                        token=activation_token,
+                        token_type=TokenType.mail_confirmation,
+                        user_id=new_user_data.id,
+                    )
+                    db.session.add(saved_token)
+                    send_confirmation_mail(username, email, confirmation_url)
                     db.session.commit()
                     login_user(new_user_data, remember=True)
                     flash("Account created successfully!", category="success")
@@ -204,12 +203,7 @@ def resend_confirmation_email():
         )
         db.session.add(saved_token)
 
-    if production:
-        send_confirmation_mail(
-            current_user.username, current_user.email, confirmation_url
-        )
-    else:
-        print(confirmation_url)
+    send_confirmation_mail(current_user.username, current_user.email, confirmation_url)
     db.session.commit()
     flash("An email with a confirmation link was sent.")
     return redirect(url_for("views.account"))
@@ -266,10 +260,7 @@ def forgot_password():
                         user_id=user.id,
                     )
                     db.session.add(saved_token)
-                    if production:
-                        send_password_reset_mail(user.username, user.email, reset_url)
-                    else:
-                        print(reset_url)
+                    send_password_reset_mail(user.username, user.email, reset_url)
                     db.session.commit()
 
             flash(

--- a/website/mailer.py
+++ b/website/mailer.py
@@ -5,6 +5,8 @@ from email.message import EmailMessage
 from os import getenv
 from smtplib import SMTP
 
+from . import production
+
 FROM_ADDR = Address(
     getenv("MAIL_FULL_NAME", "OpenRoboticPlatform"),
     getenv("MAIL_USER", "noreply"),
@@ -30,6 +32,17 @@ def check_addr_restrictions(address: Address):
             raise ValueError("Mail uses a forbidden IP address")
     elif "." not in domain:
         raise ValueError("Mail is registered under a TLD")
+
+
+def send_message(msg: EmailMessage):
+    if production:
+        with SMTP("postfix") as smtp:
+            smtp.send_message(msg)
+    else:
+        print(f'To: {msg["To"]}')
+        print(f'From: {msg["From"]}')
+        print(f'Subject: {msg["Subject"]}\n')
+        print(msg.get_body(("plain",)).get_content())
 
 
 def send_confirmation_mail(username: str, email_addr: str, url: str):
@@ -79,8 +92,7 @@ def send_confirmation_mail(username: str, email_addr: str, url: str):
         subtype="html",
     )
 
-    with SMTP("postfix") as smtp:
-        smtp.send_message(msg)
+    send_message(msg)
 
 
 def send_password_reset_mail(username: str, email_addr: str, url: str):
@@ -126,5 +138,4 @@ def send_password_reset_mail(username: str, email_addr: str, url: str):
         subtype="html",
     )
 
-    with SMTP("postfix") as smtp:
-        smtp.send_message(msg)
+    send_message(msg)


### PR DESCRIPTION
- Lock shared APT cache in docker builds and make sure that it isn't emptied
- Don't restrict server name in development
- Redirect all HTTP and HTTPS traffic to the configured domain (and HTTPS)
- Always print emails (`To`, `From`, `Subject` and text version of the body) to console in development mode