### PR TITLE
Improve page loading experience

### DIFF
--- a/prod/nginx/Dockerfile
+++ b/prod/nginx/Dockerfile
@@ -1,4 +1,13 @@
 # syntax=docker/dockerfile:1
+FROM node:current-slim as theme
+
+WORKDIR /theme
+COPY /theme .
+
+RUN --mount=type=cache,target=/root/.npm npm install
+
+RUN npm run build
+
 FROM nginx:mainline as final
 
 # Copy config files
@@ -6,6 +15,7 @@ COPY prod/nginx /etc/nginx
 
 # Prepare static files
 COPY --chmod=644 website/static /data/static
+COPY --from=theme --chmod=644 /theme/dist/styles.css /data/static/css/theme.css
 RUN find /data/static -type f -not -empty -exec sh -c "gzip -c -9 {} > {}.gz" \; && \
     find /data/static -type d -exec chmod 755 "{}" \;
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ Flask-Migrate>=4.0.4
 # Flask-SeaSurf hasn't been updated on PyPi in over a year, but the main branch contains important changes. I don't want to always use the latest changes, so it's pinned to the current latest commit.
 Flask-SeaSurf @ https://github.com/maxcountryman/flask-seasurf/archive/f383b482c69e0b0e8064a8eb89305cea3826a7b6.tar.gz#sha256=e48ccd11d33a3c3db1c9a101818773ccad31dd9574f07867951e4922072d1c29
 Flask-SQLAlchemy>=3.0.5
-flask-talisman>=1.0.0
+flask-talisman>=1.1.0
 bleach>=6.0.0
 requests>=2.31.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ Flask-SeaSurf @ https://github.com/maxcountryman/flask-seasurf/archive/f383b482c
 Flask-SQLAlchemy>=3.0.5
 flask-talisman>=1.1.0
 bleach>=6.0.0
+Pillow>=10.0.0
 requests>=2.31.0
 
 # DB driver required by SQLAlchemy

--- a/scripts/create_thumbnails.py
+++ b/scripts/create_thumbnails.py
@@ -1,0 +1,78 @@
+from mimetypes import guess_type
+from pathlib import Path
+
+from PIL import Image, UnidentifiedImageError
+
+THUMBNAIL_EXTENSIONS = [".webp"]
+THUMBNAIL_DIM = (548, 411)
+
+project_root = Path(__file__).parents[1]
+images_dir = project_root / "website" / "static" / "uploads" / "images"
+thumbnails_dir = images_dir / "thumbs"
+
+
+def generate_missing_thumbnails(source_file: Path):
+    thumb_file = thumbnails_dir / source_file.name
+    extensions = THUMBNAIL_EXTENSIONS.copy()
+    mime = guess_type(source_file)[0]
+    match mime:
+        case "image/png":
+            extensions.append(".png")
+        case "image/jpeg":
+            extensions.append(".jpg")
+        case _:
+            print(f"Unknown image format {mime}")
+            return
+
+    missing_thumbs = [
+        thumb_file.with_suffix(ext)
+        for ext in extensions
+        if not thumb_file.with_suffix(ext).is_file()
+    ]
+    if not len(missing_thumbs):
+        print("thumbnails already exist")
+        return
+
+    try:
+        with Image.open(source_file) as img:
+            thumb = make_thumbnail(img)
+            for thumb_path in missing_thumbs:
+                thumb.save(thumb_path)
+                print(thumb_path.suffix, end=" ")
+        print("")
+    except UnidentifiedImageError as e:
+        print(f"not a valid image:", e)
+
+
+def check_all_thumbnails():
+    if not thumbnails_dir.is_dir():
+        print("Creating thumbnails directory")
+        thumbnails_dir.mkdir(parents=True, exist_ok=True)
+    for image in images_dir.glob("part*"):
+        print(image, end=": ")
+        generate_missing_thumbnails(image)
+
+
+def make_thumbnail(img: Image.Image, size: tuple[int, int] = THUMBNAIL_DIM):
+    w, h = img.size
+    x = min(w // 4, h // 3)
+    cropped_w, cropped_h = 4 * x, 3 * x
+
+    if cropped_w != w or cropped_h != h:
+        offset_x, offset_y = 0, 0
+        if cropped_w < w:
+            offset_x = (w - cropped_w) // 2
+        if cropped_h < h:
+            offset_y = (h - cropped_h) // 2
+        thumb = img.crop(
+            (offset_x, offset_y, offset_x + cropped_w, offset_y + cropped_h)
+        )
+    else:
+        thumb = img
+
+    thumb.thumbnail(size, Image.LANCZOS)
+    return thumb
+
+
+if __name__ == "__main__":
+    check_all_thumbnails()

--- a/website/__init__.py
+++ b/website/__init__.py
@@ -82,7 +82,6 @@ def create_app():
         session_cookie_secure=production,
         strict_transport_security=False,  # nginx already does it
         referrer_policy="same-origin",
-        x_xss_protection=False,  # it's not supported any more, because it wasn't always working and could introduce new vulnerabilities
     )
     app.config["CSRF_COOKIE_SECURE"] = production
     app.config["CSRF_COOKIE_HTTPONLY"] = True

--- a/website/models.py
+++ b/website/models.py
@@ -1,5 +1,7 @@
 import enum
+import os
 import uuid
+from dataclasses import dataclass
 
 from flask_login import UserMixin
 from sqlalchemy.orm import Mapped
@@ -43,6 +45,23 @@ class Part(db.Model):
 
     cat = db.relationship("Category", backref=db.backref("part", lazy=True))
     author: Mapped[User] = db.relationship("User", back_populates="parts")
+
+    @property
+    def thumbnail(self):
+        @dataclass
+        class ThumbnailDetails:
+            fallback: str
+            """Fallback (jpg or png) thumbnail to be used in <img>"""
+            optimized: list[tuple[str, str]]
+            """An ordered list of (filename, mime type) tuples in preferred order"""
+
+        base, ext = os.path.splitext(self.image)
+        preferred_thumnails = [(base + ".webp", "image/webp")]
+        ext = ext.lower()
+        fallback_thumbnail = base + (".png" if ext == ".png" else ".jpg")
+        return ThumbnailDetails(
+            fallback=fallback_thumbnail, optimized=preferred_thumnails
+        )
 
 
 class File(db.Model):

--- a/website/templates/addpart.html
+++ b/website/templates/addpart.html
@@ -18,7 +18,8 @@
                         <form method="POST" enctype="multipart/form-data" class="needs-validation" novalidate>
                             <div class="mb-3">
                                 <label for="image" class="form-label">Image</label>
-                                <input type="file" class="form-control" id="image" name="image" accept="{{ image_types|join(', ') }}" data-max-size="5M" data-feedback="imageFeedback" required>
+                                <input type="file" class="form-control" id="image" name="image" accept="{{ image_types|join(', ') }}" aria-describedby="imageHelp" data-max-size="5M" data-feedback="imageFeedback" required>
+                                <div id="imageHelp" class="form-text">Minimum dimensions are 548x411 px, but not more than 64 MPx or 5 MiB.</div>
                                 <div class="invalid-feedback" id="imageFeedback">A thumbnail is required (max size 5 MiB).</div>
                                 <div id="image-preview"></div>
                             </div>

--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -17,9 +17,9 @@
         <meta name="msapplication-TileColor" content="#ffc800">
         <meta name="theme-color" content="##ffc800">
         <!-- Font Awesome icons (free version)-->
-        <script src="{{ url_for('static', filename='fa/fontawesome.min.js') }}" data-auto-add-css="false" nonce="{{ csp_nonce() }}"></script>
-        <script src="{{ url_for('static', filename='fa/brands.min.js') }}" nonce="{{ csp_nonce() }}"></script>
-        <script src="{{ url_for('static', filename='fa/solid.min.js') }}" nonce="{{ csp_nonce() }}"></script>
+        <script src="{{ url_for('static', filename='fa/fontawesome.min.js') }}" data-auto-add-css="false" defer nonce="{{ csp_nonce() }}"></script>
+        <script src="{{ url_for('static', filename='fa/brands.min.js') }}" defer nonce="{{ csp_nonce() }}"></script>
+        <script src="{{ url_for('static', filename='fa/solid.min.js') }}" defer nonce="{{ csp_nonce() }}"></script>
         <link href="{{ url_for('static', filename='fa/svg-with-js.min.css') }}" rel="stylesheet" />
         <!-- Google fonts-->
         <link href="https://fonts.googleapis.com/css?family=Montserrat:400,700&display=swap" rel="stylesheet" type="text/css" crossorigin="anonymous" />

--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -22,8 +22,8 @@
         <script src="{{ url_for('static', filename='fa/solid.min.js') }}" nonce="{{ csp_nonce() }}"></script>
         <link href="{{ url_for('static', filename='fa/svg-with-js.min.css') }}" rel="stylesheet" />
         <!-- Google fonts-->
-        <link href="https://fonts.googleapis.com/css?family=Montserrat:400,700" rel="stylesheet" type="text/css" crossorigin="anonymous" />
-        <link href="https://fonts.googleapis.com/css?family=Roboto+Slab:400,100,300,700" rel="stylesheet" type="text/css" crossorigin="anonymous" />
+        <link href="https://fonts.googleapis.com/css?family=Montserrat:400,700&display=swap" rel="stylesheet" type="text/css" crossorigin="anonymous" />
+        <link href="https://fonts.googleapis.com/css?family=Roboto+Slab:400,100,300,700&display=swap" rel="stylesheet" type="text/css" crossorigin="anonymous" />
         <!-- Core theme CSS (includes Bootstrap)-->
         <link href="{{ url_for('static', filename='css/theme.css') }}" rel="stylesheet" />
     </head>

--- a/website/templates/home.html
+++ b/website/templates/home.html
@@ -143,7 +143,12 @@
                 <a href ="/part:{{part.id}}" class="text-decoration-none">
                 <div class="card">
                     <div class="card-img-container">
-                        <img src="{{ url_for('static', filename='uploads/images/' + part.image) }}" alt="Part Image" class="card-img-top" loading="lazy"/>
+                        <picture>
+                            {% for thumbnail, mime in part.thumbnail.optimized %}
+                            <source srcset="{{ url_for('static', filename='uploads/images/thumbs/' + thumbnail) }}" type="{{ mime }}">
+                            {% endfor %}
+                            <img  class="card-img-top" src="{{ url_for('static', filename='uploads/images/thumbs/' + part.thumbnail.fallback) }}" alt="Part Image" loading="lazy">
+                        </picture>
                     </div>
                     <div class="card-body">
                         <h5 class="card-title">{{ part.name }}</h5>

--- a/website/templates/home.html
+++ b/website/templates/home.html
@@ -143,7 +143,7 @@
                 <a href ="/part:{{part.id}}" class="text-decoration-none">
                 <div class="card">
                     <div class="card-img-container">
-                        <img src="{{ url_for('static', filename='uploads/images/' + part.image) }}" alt="Part Image" class="card-img-top" />
+                        <img src="{{ url_for('static', filename='uploads/images/' + part.image) }}" alt="Part Image" class="card-img-top" loading="lazy"/>
                     </div>
                     <div class="card-body">
                         <h5 class="card-title">{{ part.name }}</h5>

--- a/website/templates/library.html
+++ b/website/templates/library.html
@@ -81,7 +81,12 @@
                 <a href="/part:{{part.id}}" class="text-decoration-none">
                 <div class="card">
                     <div class="card-img-container">
-                       <img src="{{ url_for('static', filename='uploads/images/' + part.image) }}" alt="Part Image" class="card-img-top" />
+                        <picture>
+                            {% for thumbnail, mime in part.thumbnail.optimized %}
+                            <source srcset="{{ url_for('static', filename='uploads/images/thumbs/' + thumbnail) }}" type="{{ mime }}">
+                            {% endfor %}
+                            <img class="card-img-top" src="{{ url_for('static', filename='uploads/images/thumbs/' + part.thumbnail.fallback) }}" alt="Part Image">
+                        </picture>
                     </div>
                     <div class="card-body">
                         <h5 class="card-title">{{ part.name }}</h5>

--- a/website/thumbnailer.py
+++ b/website/thumbnailer.py
@@ -1,0 +1,72 @@
+import os
+from pathlib import Path
+
+from PIL import Image
+from werkzeug.datastructures import FileStorage
+
+ImgSize = tuple[int, int]
+
+# Warn on 32 MP images, raise an error on 64 MB
+Image.MAX_IMAGE_PIXELS = 32_000_000
+
+
+# Largest possible thumbnail size is 548 x 411 px
+# Thumbnails have 4:3 aspect ratio
+def prepare_thumbnail(img: Image.Image, size: ImgSize):
+    w, h = img.size
+    x = min(w // 4, h // 3)
+    cropped_w, cropped_h = 4 * x, 3 * x
+
+    thumb = img.copy()
+    if cropped_w != w or cropped_h != h:
+        offset_x, offset_y = 0, 0
+        if cropped_w < w:
+            offset_x = (w - cropped_w) // 2
+        if cropped_h < h:
+            offset_y = (h - cropped_h) // 2
+        thumb = thumb.crop(
+            (offset_x, offset_y, offset_x + cropped_w, offset_y + cropped_h)
+        )
+
+    thumb.thumbnail(size, Image.LANCZOS)
+    return thumb
+
+
+def create_thumbnails(
+    img: Image.Image,
+    dir: str | Path,
+    filename: str,
+    size: ImgSize = (548, 411),
+    extensions: list[str] = [".webp"],
+):
+    thumb = prepare_thumbnail(img, size)
+    dir = Path(dir)
+    if not dir.is_dir():
+        dir.mkdir(parents=True, exist_ok=True)
+
+    basename, _ = os.path.splitext(filename)
+    match img.format:
+        case "PNG":
+            extensions.append(".png")
+        case "JPEG":
+            extensions.append(".jpg")
+        case _:
+            raise RuntimeError(f"Unknown format {img.format}")
+    for ext in extensions:
+        fname = f"{basename}{ext}"
+        dest = dir / fname
+        thumb.save(dest)
+
+
+def load_check_image(
+    file: FileStorage, min_size: ImgSize = (548, 411), allowed_formats=("JPEG", "PNG")
+):
+    img = Image.open(file, formats=allowed_formats)
+
+    w, h = img.size
+    if w < min_size[0] or h < min_size[1]:
+        raise ValueError(
+            f"Image is too small. Expected at least {min_size[0]}x{min_size[1]} px, but the image is only {w}x{h} px."
+        )
+
+    return img


### PR DESCRIPTION
This PR introduces a few simple page loading UX improvements:

- Text is not invisible before fonts are loaded
- FontAwesome script is not render-blocking
- Latest part previews on homepage have `loading="lazy"`, because they are not visible unless the user scrolls down
- Part previews on homepage and in the library use thumbnails, which saves a lot of bandwidth

Lighthouse results (homepage):

<details>
<summary>Before</summary>

![Lighthouse results - before: performance 73](https://github.com/Indystrycc/OpenRoboticPlatform-website/assets/12915102/d1cc6b67-288a-412c-995b-2080992fcc2c)

</details>

<details>
<summary>After</summary>

![Lighthouse results - after: performance 92](https://github.com/Indystrycc/OpenRoboticPlatform-website/assets/12915102/50ba46a4-149e-4add-a5dd-9fbfb94a99e5)

</details>

To generate thumbnails for existing images, run `scripts/create_thumbnails.py`. This file is not copied to the docker image, so you'll have to copy it there by yourself.

I'd also like to save thumbnails as JPEG XL, but it isn't supported yet by Pillow.