### PR TITLE
Add simple Open Graph metadata to parts and users

### DIFF
--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -26,6 +26,7 @@
         <link href="https://fonts.googleapis.com/css?family=Roboto+Slab:400,100,300,700&display=swap" rel="stylesheet" type="text/css" crossorigin="anonymous" />
         <!-- Core theme CSS (includes Bootstrap)-->
         <link href="{{ url_for('static', filename='css/theme.css') }}" rel="stylesheet" />
+        {% block head_additional %}{% endblock %}
     </head>
     <body id="page-top">
         <!-- Navigation-->

--- a/website/templates/part.html
+++ b/website/templates/part.html
@@ -1,5 +1,15 @@
 {% extends "base.html" %}
-{% block title %}{{ part.name }} by {{author.username}} {% endblock %}
+{% block title %}{{ part.name }} by {{author.username}}{% endblock %}
+{% block head_additional %}
+<!-- Open Graph metadata -->
+<meta property="og:title" content="ORP - {{ part.name }} by {{ author.username }}">
+<meta property="og:url" content="{{ url_for('views.part', part_number=part.id, _external=True, _scheme='https') }}">
+<meta property="og:image" content="{{ url_for('static', filename='uploads/images/' + part.image, _external=True, _scheme='https') }}">
+<meta property="og:image:alt" content="{{ part.name }}">
+<meta property="og:site_name" content="Open Robotic Platform">
+<meta property="og:type" content="object">
+<meta property="og:description" content="{{ part.description }}">
+{% endblock %}
 {% block navbar_add_class %}masthead-no-img{% endblock %}
 {% block header %}
 <header class="masthead masthead-no-img">

--- a/website/templates/user.html
+++ b/website/templates/user.html
@@ -1,5 +1,21 @@
 {% extends "base.html" %}
 {% block title %}{{ display_user.username }}{% endblock %}
+{% block head_additional %}
+<!-- Open Graph metadata -->
+<meta property="og:title" content="ORP - {{ display_user.username }}">
+<meta property="og:url" content="{{ url_for('views.userView', user_name=display_user.username, _external=True, _scheme='https') }}">
+{% if display_user.image %}
+<meta property="og:image" content="{{ url_for('static', filename='uploads/profile_images/' + display_user.image, _external=True, _scheme='https') }}">
+<meta property="og:image:alt" content="{{ display_user.username }} profile picture">
+{% else %}
+<meta property="og:image" content="{{ url_for('static', filename='assets/img/opt/default_avatar.png', _external=True, _scheme='https') }}">
+<meta property="og:image:alt" content="default profile picture">
+{% endif %}
+<meta property="og:site_name" content="Open Robotic Platform">
+<meta property="og:type" content="profile">
+<meta property="profile:username" content="{{ display_user.username }}">
+<meta property="og:description" content="{{ display_user.username }}, an author of {{ user_parts }} part{% if user_parts != 1 %}s{% endif %}{% if display_user.description %}: {{ display_user.description }}{% else %}.{% endif %}">
+{% endblock %}
 {% block navbar_add_class %}masthead-no-img{% endblock %}
 {% block header%}
 <header class="masthead masthead-no-img">


### PR DESCRIPTION
Links shared on e.g. Discord, Signal and Facebook have more information associated with them:

![Open Graph demonstration on Discord](https://github.com/Indystrycc/OpenRoboticPlatform-website/assets/12915102/2019f858-4687-48cc-9835-8b7b6fde98d2)
![Open Graph demonstration on Signal](https://github.com/Indystrycc/OpenRoboticPlatform-website/assets/12915102/c63f7c59-5203-41e9-93bf-b2707823bb69)

