### PR TITLE
Allow disabling COEP per-route and easier CSP updates

### DIFF
--- a/migrations/versions/1760d857367e_add_email_tokens.py
+++ b/migrations/versions/1760d857367e_add_email_tokens.py
@@ -5,6 +5,7 @@ Revises: 97e7bd98496d
 Create Date: 2023-08-02 03:33:30.251394
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/migrations/versions/1d21145a4fde_add_part_last_modified.py
+++ b/migrations/versions/1d21145a4fde_add_part_last_modified.py
@@ -5,6 +5,7 @@ Revises: 1760d857367e
 Create Date: 2023-09-15 01:23:55.059799
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/migrations/versions/5820e7dd0602_add_categories_table.py
+++ b/migrations/versions/5820e7dd0602_add_categories_table.py
@@ -5,6 +5,7 @@ Revises: 6139f6e9a81a
 Create Date: 2023-06-29 00:52:26.957222
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/migrations/versions/6139f6e9a81a_initial_migration.py
+++ b/migrations/versions/6139f6e9a81a_initial_migration.py
@@ -5,6 +5,7 @@ Revises:
 Create Date: 2023-06-28 23:22:01.512576
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 

--- a/migrations/versions/79309a9026b9_add_views_table_and_user_registration.py
+++ b/migrations/versions/79309a9026b9_add_views_table_and_user_registration.py
@@ -5,6 +5,7 @@ Revises: 5820e7dd0602
 Create Date: 2023-07-26 15:51:51.637710
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/migrations/versions/97e7bd98496d_add_stats_table.py
+++ b/migrations/versions/97e7bd98496d_add_stats_table.py
@@ -5,6 +5,7 @@ Revises: 79309a9026b9
 Create Date: 2023-07-29 10:49:10.560728
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 

--- a/migrations/versions/c1e22fc078c5_nullable_and_default_changes_moving_to_.py
+++ b/migrations/versions/c1e22fc078c5_nullable_and_default_changes_moving_to_.py
@@ -5,6 +5,7 @@ Revises: 1d21145a4fde
 Create Date: 2023-09-17 00:16:13.546667
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import mysql

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,11 +1,11 @@
 # Install the base requirements too
 -r requirements.txt
 
-black>=23.11.0
-mypy>=1.7.0
+black>=24.1.1
+mypy>=1.8.0
 
 types-bleach>=6.1.0.1
 types-Flask-Migrate>=4.0.0.7
 types-mysqlclient>=2.2.0.1
-types-Pillow>=10.1.0.2
-types-requests>=2.31.0.10
+types-Pillow>=10.2.0.20240125
+types-requests>=2.31.0.20240125

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-flask>=3.0.0
+flask>=3.0.1
 Flask-Login>=0.6.3
 Flask-Migrate>=4.0.5
 # Flask-SeaSurf hasn't been updated on PyPi in over a year, but the main branch contains important changes. I don't want to always use the latest changes, so it's pinned to the current latest commit.
@@ -6,12 +6,12 @@ Flask-SeaSurf @ https://github.com/maxcountryman/flask-seasurf/archive/f383b482c
 Flask-SQLAlchemy>=3.1.1
 flask-talisman>=1.1.0
 bleach>=6.1.0
-Pillow>=10.1.0
+Pillow>=10.2.0
 requests>=2.31.0
 
 # DB driver required by SQLAlchemy
-mysqlclient>=2.2.0
+mysqlclient>=2.2.1
 
 # dependencies of Flask-* dependencies, but we're using them directly, so make sure that they are installed
-SQLAlchemy>=2.0.23
+SQLAlchemy>=2.0.25
 Werkzeug>=3.0.1

--- a/typings/flask_talisman/talisman.pyi
+++ b/typings/flask_talisman/talisman.pyi
@@ -7,9 +7,9 @@ DENY: Literal["DENY"] = "DENY"
 SAMEORIGIN: Literal["SAMEORIGIN"] = "SAMEORIGIN"
 ALLOW_FROM: Literal["ALLOW-FROM"] = "ALLOW-FROM"
 ONE_YEAR_IN_SECS: Literal[31556926] = 31556926
-DEFAULT_REFERRER_POLICY: Literal[
+DEFAULT_REFERRER_POLICY: Literal["strict-origin-when-cross-origin"] = (
     "strict-origin-when-cross-origin"
-] = "strict-origin-when-cross-origin"
+)
 DEFAULT_CSP_POLICY = {
     "default-src": "'self'",
     "object-src": "'none'",
@@ -120,8 +120,9 @@ class Talisman:
         strict_transport_security_preload: bool = False,
         strict_transport_security_max_age: int = ONE_YEAR_IN_SECS,
         strict_transport_security_include_subdomains: bool = True,
-        content_security_policy: Mapping[str, str | Sequence[str]]
-        | str = DEFAULT_CSP_POLICY,
+        content_security_policy: (
+            Mapping[str, str | Sequence[str]] | str
+        ) = DEFAULT_CSP_POLICY,
         content_security_policy_report_uri: str | None = None,
         content_security_policy_report_only: bool = False,
         content_security_policy_nonce_in: Sequence[str] | None = [],

--- a/website/utils.py
+++ b/website/utils.py
@@ -1,0 +1,23 @@
+from typing import Mapping
+
+
+def merge_arr(a: str | list[str], b: str | list[str]) -> str | list[str]:
+    if a == "":
+        return b
+    if b == "":
+        return a
+    a = [a] if isinstance(a, str) else a
+    return a + [b] if isinstance(b, str) else a + b
+
+
+def extend_talisman_csp(
+    base_csp: dict[str, str | list[str]], *extensions: Mapping[str, str | list[str]]
+) -> dict[str, str | list[str]]:
+    copy = base_csp.copy()
+    for extension in extensions:
+        for key, value in extension.items():
+            if key not in copy:
+                copy[key] = value
+            else:
+                copy[key] = merge_arr(copy[key], value)
+    return copy

--- a/website/views.py
+++ b/website/views.py
@@ -27,12 +27,20 @@ from sqlalchemy.orm import joinedload
 from werkzeug.datastructures import FileStorage
 from werkzeug.utils import secure_filename
 
-from . import compression_process, db
+from . import (
+    compression_process,
+    csp_kickstarter_ext,
+    db,
+    default_csp,
+    disable_COEP,
+    talisman,
+)
 from .compression import compress_uploads
 from .models import Category, File, Part, Stats, User, View
 from .secrets_manager import MAILERLITE_API_KEY
 from .session_utils import get_session, get_user
 from .thumbnailer import create_thumbnails, load_check_image
+from .utils import extend_talisman_csp
 
 ALLOWED_IMAGE_MIME = ["image/png", "image/jpeg"]
 ALLOWED_PART_EXTENSIONS = [".3mf", ".stl", ".step", ".dxf", ".scad"]
@@ -40,6 +48,8 @@ views = Blueprint("views", __name__)
 
 
 @views.route("/")
+@talisman(content_security_policy=extend_talisman_csp(default_csp, csp_kickstarter_ext))
+@disable_COEP
 def home() -> ResponseReturnValue:
     parts = db.session.scalars(
         select(Part).where(Part.rejected == False).order_by(Part.date.desc()).limit(10)


### PR DESCRIPTION
Since some websites (e.g. YouTube) which offer embeddable widgets do not work with site isolation (COEP), this PR allows us to disable COEP on some pages and makes it easier to add things to CSP.

COEP is disabled on `/`, which additionally has CSP that enables frames from Kickstarter.

Real changes are in a13b039036d21e99d51dda72eb04651393d5ca7d, other commits adjust the code to the newer black version.