### PR TITLE
Decode bytes from b64encode in `url_for`

### DIFF
--- a/website/auth.py
+++ b/website/auth.py
@@ -99,7 +99,9 @@ def sign_up() -> ResponseReturnValue:
                         ".confirm_email",
                         _scheme="https",
                         _external=True,
-                        token_enc=base64.urlsafe_b64encode(activation_token),
+                        token_enc=base64.urlsafe_b64encode(activation_token).decode(
+                            "ascii"
+                        ),
                     )
                     saved_token = EmailToken(
                         token=activation_token,
@@ -196,7 +198,7 @@ def resend_confirmation_email() -> ResponseReturnValue:
         ".confirm_email",
         _scheme="https",
         _external=True,
-        token_enc=base64.urlsafe_b64encode(activation_token),
+        token_enc=base64.urlsafe_b64encode(activation_token).decode("ascii"),
     )
     if saved_token:
         saved_token.token = activation_token
@@ -257,7 +259,9 @@ def forgot_password() -> ResponseReturnValue:
                         ".reset_password_token",
                         _scheme="https",
                         _external=True,
-                        token_enc=base64.urlsafe_b64encode(activation_token),
+                        token_enc=base64.urlsafe_b64encode(activation_token).decode(
+                            "ascii"
+                        ),
                     )
                     saved_token = EmailToken(
                         token=activation_token,


### PR DESCRIPTION
`base64.urlsafe_b64encode()` returns `bytes` for some reason and since Werkzeug 3.0 `bytes` are not automatically converted to string:

> - Passing bytes where strings are expected is deprecated.
https://werkzeug.palletsprojects.com/en/3.0.x/changes/#version-2-3-0

> - Remove previously deprecated code
https://werkzeug.palletsprojects.com/en/3.0.x/changes/#version-3-0-0

This should fix all problems with tokens in emails (email confirmation and password reset).