### PR TITLE
Re-enable COEP in nginx with an option to disable

### DIFF
--- a/prod/nginx/templates/default.conf.template
+++ b/prod/nginx/templates/default.conf.template
@@ -51,8 +51,12 @@ map $upstream_http_cross_origin_opener_policy $coop {
 map $upstream_http_cross_origin_resource_policy $corp {
     '' "same-origin";
 }
-map $upstream_http_cross_origin_embedder_policy $coep {
+map $upstream_http_cross_origin_embedder_policy $coep_val {
     '' "require-corp";
+}
+map $upstream_http___no_implicit_coep $coep {
+    default $coep_val;
+    1       "";
 }
 map $upstream_http_permissions_policy $pp {
     '' "accelerometer=(), camera=(), browsing-topics=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()";
@@ -81,8 +85,9 @@ server {
     add_header Content-Security-Policy $csp always;
     add_header Cross-Origin-Opener-Policy $coop always;
     add_header Cross-Origin-Resource-Policy $corp always;
-    # add_header Cross-Origin-Embedder-Policy $coep always;
+    add_header Cross-Origin-Embedder-Policy $coep always;
     add_header Permissions-Policy $pp always;
+    proxy_hide_header  __No-Implicit-COEP;
 
     location / {
         proxy_pass http://unix:/run/gunicorn/gunicorn.sock;

--- a/website/__init__.py
+++ b/website/__init__.py
@@ -135,9 +135,12 @@ def create_app() -> Flask:
         # block no-cors cross-origin requests to our site, change it (on /static) if we want to allow cross-origin embedding of our resources
         response.headers.set("Cross-Origin-Resource-Policy", "same-origin")
         # Allow disabling COEP, because Kickstarter and YouTube embeds/iframes do not have CORP header (why???) and credentialless iframes are not a thing
-        if not ("disable_COEP" in g and g.disable_COEP):
+        if not g.get("disable_COEP", False):
             # only allow loading resources with CORP or (if marked as crossorigin) CORS
             response.headers.set("Cross-Origin-Embedder-Policy", "require-corp")
+        elif production:
+            # Make sure that nginx does not implicitly add the COEP header to this response
+            response.headers.set("__No-Implicit-COEP", "1")
         return response
 
     @app.context_processor


### PR DESCRIPTION
The implicit COEP header set by nginx can be disabled by the upstream server by sending `__No-Implicit-COEP: 1` header in the response. This header will be set automatically in production mode if COEP is disabled using `g.disable_COEP` (set by the `@disable_COEP` decorator). `__No-Implicit-COEP` is not passed to the client.

Fix to a problem with #39, reverts 81940072b208763108eb8a9865871ba4e01eed21