### PR TITLE
Add analytics (self-hosted Matomo)

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -3,7 +3,7 @@ name: openroboticplatform
 x-database: &db-base
   image: mariadb:10
   container_name: db
-  command: ["--event_scheduler=ON"]
+  command: ["--event_scheduler=ON", "--max_allowed_packet=64M"]
   environment:
     - MARIADB_ROOT_PASSWORD=rootroot
     - MARIADB_DATABASE=orp_db
@@ -104,12 +104,35 @@ services:
     volumes:
       - uploads:/data/static/uploads
       - proxy-conn-sock:/run/gunicorn
+      - matomo:/var/www/html
+      - matomo-sock:/run/matomo
     secrets:
       - chain
       - fullchain
       - privkey
     network_mode: host
     restart: on-failure
+    profiles:
+      - prod
+
+  matomo:
+    build:
+      context: prod/matomo
+      dockerfile: Dockerfile
+    container_name: matomo
+    depends_on:
+      - db-prod
+    environment:
+      - MATOMO_DATABASE_HOST=db
+      - MATOMO_DATABASE_USERNAME=root
+      - MATOMO_DATABASE_PASSWORD=rootroot
+      - MATOMO_DATABASE_DBNAME=matomo_db
+    volumes:
+      - matomo:/var/www/html
+      - matomo-sock:/run/matomo
+    networks:
+      - dbnet
+    restart: unless-stopped
     profiles:
       - prod
 
@@ -155,6 +178,8 @@ volumes:
   dbdata:
   uploads:
   proxy-conn-sock:
+  matomo:
+  matomo-sock:
   opendkim-keys:
 
 networks:

--- a/prod/matomo/Dockerfile
+++ b/prod/matomo/Dockerfile
@@ -1,0 +1,11 @@
+# syntax=docker/dockerfile:1
+FROM matomo:fpm as final
+
+# Configure php-fpm to listen on a UNIX socket
+RUN sed -E -i "s,^listen = (127\.0\.0\.1:)?9000\$,listen = /run/matomo/matomo.sock\nlisten.mode = 0666,gm" /usr/local/etc/php-fpm.d/*
+# Override default settings to make it work behind a proxy
+RUN sed -i \
+    -e "s/^;proxy_client_headers\[\] = HTTP_X_FORWARDED_FOR\$/proxy_client_headers[] = HTTP_X_FORWARDED_FOR/gm" \
+    -e "s/^;proxy_host_headers\[\] = HTTP_X_FORWARDED_HOST\$/proxy_host_headers[] = HTTP_X_FORWARDED_HOST/gm" \
+    -e "s/^force_ssl = 0\$/force_ssl = 1/gm" \
+    /usr/src/matomo/config/global.ini.php

--- a/prod/nginx/templates/default.conf.template
+++ b/prod/nginx/templates/default.conf.template
@@ -123,3 +123,95 @@ server {
         expires $expires;
     }
 }
+
+server {
+    # https://github.com/matomo-org/docker/blob/master/.examples/nginx/matomo.conf
+    listen 443 quic;
+    listen 443 ssl;
+    listen [::]:443 quic;
+    listen [::]:443 ssl;
+
+    server_name analytics.${DOMAIN};
+
+    http2 on;
+
+    include conf.d/ssl_common.conf;
+
+    # required for browsers to direct them into quic port
+    add_header Alt-Svc 'h3=":443"; ma=86400';
+
+    add_header X-Content-Type-Options $nosniff always;
+    add_header Referrer-Policy same-origin always;
+    add_header Cross-Origin-Resource-Policy same-site always;
+
+    root /var/www/html;
+    index index.php;
+    try_files $uri $uri/ =404;
+
+    ## only allow accessing the following php files
+    location ~ ^/(index|matomo|piwik|js/index|plugins/HeatmapSessionRecording/configs).php {
+        # regex to split $uri to $fastcgi_script_name and $fastcgi_path
+        fastcgi_split_path_info ^(.+\.php)(/.+)$;
+
+        # Check that the PHP script exists before passing it
+        try_files $fastcgi_script_name =404;
+
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_param PATH_INFO $fastcgi_path_info;
+        fastcgi_param HTTP_PROXY ""; # prohibit httpoxy: https://httpoxy.org/
+
+        fastcgi_param HTTP_X_FORWARDED_FOR $proxy_add_x_forwarded_for;
+        fastcgi_param HTTP_X_FORWARDED_PROTO $scheme;
+        fastcgi_param HTTP_X_FORWARDED_HOST $host;
+        fastcgi_param HTTP_X_FORWARDED_PREFIX /;
+
+        fastcgi_pass unix:/run/matomo/matomo.sock;
+    }
+
+    ## deny access to all other .php files
+    location ~* ^.+\.php$ {
+        deny all;
+        return 403;
+    }
+
+    ## disable all access to the following directories
+    location ~ /(config|tmp|core|lang) {
+        deny all;
+        return 403; # replace with 404 to not show these directories exist
+    }
+    location ~ /\.ht {
+        deny all;
+        return 403;
+    }
+
+    location ~ js/container_.*_preview\.js$ {
+        expires off;
+        add_header Cache-Control 'private, no-cache, no-store';
+        add_header X-Content-Type-Options $nosniff always;
+        add_header Referrer-Policy same-origin always;
+        add_header Cross-Origin-Resource-Policy same-site always;
+    }
+
+    location ~ \.(gif|ico|jpg|png|svg|js|css|htm|html|mp3|mp4|wav|ogg|avi|ttf|eot|woff|woff2|json)$ {
+        allow all;
+        ## Cache images,CSS,JS and webfonts for an hour
+        ## Increasing the duration may improve the load-time, but may cause old files to show after an Matomo upgrade
+        expires 1h;
+        add_header Pragma public;
+        add_header Cache-Control "public";
+        add_header X-Content-Type-Options $nosniff always;
+        add_header Referrer-Policy same-origin always;
+        add_header Cross-Origin-Resource-Policy same-site always;
+    }
+
+    location ~ /(libs|vendor|plugins|misc/user) {
+        deny all;
+        return 403;
+    }
+
+    ## properly display textfiles in root directory
+    location ~/(.*\.md|LEGALNOTICE|LICENSE) {
+        default_type text/plain;
+    }
+}

--- a/scripts/cnf/server.cnf
+++ b/scripts/cnf/server.cnf
@@ -40,6 +40,7 @@ nsComment            = "OpenSSL Generated Certificate for ORP dev"
 DNS.1  = orp.localhost
 DNS.2  = localhost
 DNS.3  = orp.testing
+DNS.4  = *.orp.testing
 
 IP.1 = 127.0.0.1
 IP.2 = ::1

--- a/theme/scss/utilities/spacing.scss
+++ b/theme/scss/utilities/spacing.scss
@@ -13,5 +13,11 @@ $utilities: map-merge(
                 ),
             ),
         ),
+        "width": map-merge(
+            map-get($utilities, "width"),
+            (
+                responsive: true
+            )
+        )
     )
 );

--- a/website/__init__.py
+++ b/website/__init__.py
@@ -4,7 +4,7 @@ from functools import wraps
 from os import getenv, path
 from typing import Any, Callable, ParamSpec, TypeVar
 
-from flask import Flask, Response, g, send_from_directory
+from flask import Flask, Response, g, request, send_from_directory
 from flask_login import LoginManager
 from flask_migrate import Migrate
 from flask_seasurf import SeaSurf
@@ -137,6 +137,10 @@ def create_app() -> Flask:
     @login_manager.user_loader
     def load_user(id: str) -> models.User | None:
         return db.session.get(models.User, uuid.UUID(id))
+
+    @app.before_request
+    def initialize_request_vars():
+        g.DNT = request.headers.get("DNT", "0") == "1"
 
     @app.after_request
     def set_important_headers(response: Response) -> Response:

--- a/website/static/css/theme.css
+++ b/website/static/css/theme.css
@@ -1,7 +1,7 @@
 @charset "UTF-8";
 /*!
 * Start Bootstrap - Agency v7.0.12-orp (https://startbootstrap.com/theme/agency)
-* Copyright 2013-2023 Start Bootstrap
+* Copyright 2013-2024 Start Bootstrap
 * Licensed under MIT (https://github.com/StartBootstrap/startbootstrap-agency/blob/master/LICENSE)
 * Modified by Indystrycc
 */
@@ -9197,6 +9197,21 @@ textarea.form-control-lg {
   .d-sm-none {
     display: none !important;
   }
+  .w-sm-25 {
+    width: 25% !important;
+  }
+  .w-sm-50 {
+    width: 50% !important;
+  }
+  .w-sm-75 {
+    width: 75% !important;
+  }
+  .w-sm-100 {
+    width: 100% !important;
+  }
+  .w-sm-auto {
+    width: auto !important;
+  }
   .flex-sm-fill {
     flex: 1 1 auto !important;
   }
@@ -9761,6 +9776,21 @@ textarea.form-control-lg {
   }
   .d-md-none {
     display: none !important;
+  }
+  .w-md-25 {
+    width: 25% !important;
+  }
+  .w-md-50 {
+    width: 50% !important;
+  }
+  .w-md-75 {
+    width: 75% !important;
+  }
+  .w-md-100 {
+    width: 100% !important;
+  }
+  .w-md-auto {
+    width: auto !important;
   }
   .flex-md-fill {
     flex: 1 1 auto !important;
@@ -10327,6 +10357,21 @@ textarea.form-control-lg {
   .d-lg-none {
     display: none !important;
   }
+  .w-lg-25 {
+    width: 25% !important;
+  }
+  .w-lg-50 {
+    width: 50% !important;
+  }
+  .w-lg-75 {
+    width: 75% !important;
+  }
+  .w-lg-100 {
+    width: 100% !important;
+  }
+  .w-lg-auto {
+    width: auto !important;
+  }
   .flex-lg-fill {
     flex: 1 1 auto !important;
   }
@@ -10892,6 +10937,21 @@ textarea.form-control-lg {
   .d-xl-none {
     display: none !important;
   }
+  .w-xl-25 {
+    width: 25% !important;
+  }
+  .w-xl-50 {
+    width: 50% !important;
+  }
+  .w-xl-75 {
+    width: 75% !important;
+  }
+  .w-xl-100 {
+    width: 100% !important;
+  }
+  .w-xl-auto {
+    width: auto !important;
+  }
   .flex-xl-fill {
     flex: 1 1 auto !important;
   }
@@ -11456,6 +11516,21 @@ textarea.form-control-lg {
   }
   .d-xxl-none {
     display: none !important;
+  }
+  .w-xxl-25 {
+    width: 25% !important;
+  }
+  .w-xxl-50 {
+    width: 50% !important;
+  }
+  .w-xxl-75 {
+    width: 75% !important;
+  }
+  .w-xxl-100 {
+    width: 100% !important;
+  }
+  .w-xxl-auto {
+    width: auto !important;
   }
   .flex-xxl-fill {
     flex: 1 1 auto !important;

--- a/website/static/js/cookie-banner.js
+++ b/website/static/js/cookie-banner.js
@@ -1,0 +1,34 @@
+const BANNER_CLOSED_COOKIE = "cookie_closed";
+
+function cookieBannerClosed() {
+    return document.cookie
+        .split(";")
+        .map(c => c.split("="))
+        .some(([k, v]) => k.trim() === BANNER_CLOSED_COOKIE && v.trim());
+}
+
+window.addEventListener("DOMContentLoaded", () => {
+    const banner = document.getElementById("cookieBanner");
+    const btnOptIn = document.getElementById("btnOptIn");
+    const btnOptOut = document.getElementById("btnOptOut");
+
+    function closeBanner() {
+        document.cookie = BANNER_CLOSED_COOKIE + "=1";
+        banner.classList.add("d-none");
+    }
+
+    btnOptIn.addEventListener("click", () => {
+        _paq?.push(["forgetUserOptOut"]);
+        closeBanner();
+    });
+    btnOptOut.addEventListener("click", () => {
+        _paq?.push(["optUserOut"]);
+        closeBanner();
+    })
+
+    _paq?.push([function () {
+        if (!this.isUserOptedOut() && !cookieBannerClosed()) {
+            banner.classList.remove("d-none");
+        }
+    }]);
+});

--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -26,6 +26,23 @@
         <link href="https://fonts.googleapis.com/css?family=Roboto+Slab:400,100,300,700&display=swap" rel="stylesheet" type="text/css" crossorigin="anonymous" />
         <!-- Core theme CSS (includes Bootstrap)-->
         <link href="{{ url_for('static', filename='css/theme.css') }}" rel="stylesheet" />
+        {% if ENV_production %}
+        <!-- Matomo -->
+        <script nonce="{{ csp_nonce() }}">
+            var _paq = window._paq = window._paq || [];
+            /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+            _paq.push(['trackPageView']);
+            _paq.push(['enableLinkTracking']);
+            (function() {
+                var u="https://analytics.{{ DOMAIN }}/";
+                _paq.push(['setTrackerUrl', u+'matomo.php']);
+                _paq.push(['setSiteId', '1']);
+                var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+                g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+            })();
+        </script>
+        <!-- End Matomo Code -->
+        {% endif %}
         {% block head_additional %}{% endblock %}
     </head>
     <body id="page-top">

--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -26,7 +26,7 @@
         <link href="https://fonts.googleapis.com/css?family=Roboto+Slab:400,100,300,700&display=swap" rel="stylesheet" type="text/css" crossorigin="anonymous" />
         <!-- Core theme CSS (includes Bootstrap)-->
         <link href="{{ url_for('static', filename='css/theme.css') }}" rel="stylesheet" />
-        {% if ENV_production %}
+        {% if ENV_production and not g.DNT and not g.get('no_analytics', False) %}
         <!-- Matomo -->
         <script nonce="{{ csp_nonce() }}">
             var _paq = window._paq = window._paq || [];
@@ -118,6 +118,16 @@
         </div>
     </div>
 </footer>
+{% if ENV_production and not g.DNT and not request.cookies.get('cookie_closed', False) %}
+<div id="cookieBanner" class="bg-body p-2 rounded-2 position-fixed bottom-0 end-0 border border-primary m-1 w-sm-75 w-md-50 w-lg-auto d-none">
+    <div>This website uses cookies to provide essential functionality and for analytical purposes.</div>
+    <div class="d-flex justify-content-between flex-column-reverse flex-sm-row mt-1">
+        <button type="button" id="btnOptOut" class="btn btn-outline-primary mt-1 mt-sm-0">Reject optional</button>
+        <button type="button" id="btnOptIn" class="btn btn-primary">Accept all</button>
+    </div>
+</div>
+<script type="module" src="{{ url_for('static', filename='js/cookie-banner.js') }}" nonce="{{ csp_nonce() }}"></script>
+{% endif %}
 
         <!-- Bootstrap core JS-->
         <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js" integrity="sha512-VK2zcvntEufaimc+efOYi622VN5ZacdnufnmX7zIhCPmjhKnOi9ZDMtg1/ug5l183f19gG1/cBstPO4D8N/Img==" crossorigin="anonymous" nonce="{{ csp_nonce() }}"></script>

--- a/website/templates/part.html
+++ b/website/templates/part.html
@@ -75,7 +75,7 @@
                         {% for file in files_list %}
                             <div class="d-flex justify-content-between align-items-center mb-1 fs-6">
                                 <p class="mb-0">{{ file.file_name }}</p>
-                                <a href="{{ url_for('static', filename='uploads/files/' + file.file_name) }}" class="btn btn-warning btn-sm">Download</a>
+                                <a href="{{ url_for('static', filename='uploads/files/' + file.file_name) }}" class="btn btn-warning btn-sm matomo_download">Download</a>
                             </div>
                             <hr>
                         {% endfor %}

--- a/website/views_admin.py
+++ b/website/views_admin.py
@@ -2,8 +2,17 @@ from functools import wraps
 from typing import Callable, ParamSpec, TypeVar
 
 from bleach import clean
-from flask import Blueprint, abort, flash, redirect, render_template, request, url_for
-from flask.typing import BeforeRequestCallable, ResponseReturnValue, RouteCallable
+from flask import (
+    Blueprint,
+    abort,
+    flash,
+    g,
+    redirect,
+    render_template,
+    request,
+    url_for,
+)
+from flask.typing import ResponseReturnValue
 from flask_login import login_required
 from markupsafe import Markup
 from sqlalchemy import exists, select
@@ -36,7 +45,8 @@ def admin_required(
 @login_required
 @admin_required
 def before_request() -> None:
-    pass
+    # It doesn't really make sense to monitor the usage of admin panel
+    g.no_analytics = True
 
 
 @views_admin.route("/panel")


### PR DESCRIPTION
Add self-hosted Matomo for analytics. The Matomo instance should be available under `https://analytics.{DOMAIN}` and must be configured before it can be used. It'll warn about modified `global.ini.php` config file, but it is the only way to preconfigure the instance to work behind nginx, as `config.ini.php` is created later.

The script responsible for loading matomo is rendered only in the production mode if the request does not have [`DNT: 1`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/DNT) header (it's deprecated, but all browsers except Safari still support it and [Privacy Badger](https://privacybadger.org/) sets it by default). [GPC](https://globalprivacycontrol.org/) is not checked, because AFAIK it concerns selling and sharing data, so private analytics should be ok.

TODO:

- [ ] Create a privacy policy page?
- [ ] Better design and wording for the cookie banner
- [ ] Make it possible to somehow change the decision without clearing cookies (privacy policy page?)
- [ ] Consider switching from [opt-out](https://developer.matomo.org/guides/tracking-javascript#managing-opt-out) (`isUserOptedOut` and `optUserOut`) to [opt-in](https://developer.matomo.org/guides/tracking-javascript#managing-consent) (`requireConsent` + `hasRememberedConsent` and `setConsentGiven`)