### PR TITLE
Use type decorator to make sure datetimes have time zone information

### DIFF
--- a/website/auth.py
+++ b/website/auth.py
@@ -178,9 +178,7 @@ def resend_confirmation_email() -> ResponseReturnValue:
     )
     # Allow resending email every 5 minutes
     allowed_after = (
-        (saved_token.created_on.replace(tzinfo=UTC) + timedelta(minutes=5))
-        if saved_token
-        else None
+        (saved_token.created_on + timedelta(minutes=5)) if saved_token else None
     )
     now = datetime.now(UTC)
     if allowed_after and now <= allowed_after:

--- a/website/views.py
+++ b/website/views.py
@@ -36,7 +36,7 @@ from . import (
     talisman,
 )
 from .compression import compress_uploads
-from .models import Category, File, Part, Stats, User, View, Comment
+from .models import Category, Comment, File, Part, Stats, User, View
 from .secrets_manager import MAILERLITE_API_KEY
 from .session_utils import get_session, get_user
 from .thumbnailer import create_thumbnails, load_check_image
@@ -259,10 +259,6 @@ def part(part_number: int) -> ResponseReturnValue:
             new_view = View(user_id=None, ip=ip_address, part_id=part_number)
         db.session.add(new_view)
         db.session.commit()
-
-    # DB does not store timezone, but it's always UTC
-    if part.last_modified is not None:
-        part.last_modified = part.last_modified.replace(tzinfo=UTC)
 
     # Get top-level comments
     comments = (


### PR DESCRIPTION
This solves the problem with comment times not showing in user's time zone. Additionally, 2 now unnecessary `.replace(tzinfo=UTC)` were removed.

It should also help us in the future by forcing all `datetime`s to have time zone information and be stored in database as their UTC representations.

Resolves https://github.com/Indystrycc/OpenRoboticPlatform-website/pull/51#discussion_r2019541036