### PR TITLE
Use uWSGI instead of HTTP for proxy<->backend communication

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -67,7 +67,6 @@ services:
       - prod/config.env
     environment:
       <<: *website-base-env
-      TRUSTED_PROXIES: "1"
       FLASK_ENV: "production"
     volumes:
       - uploads:/app/website/static/uploads

--- a/prod/gunicorn.conf.py
+++ b/prod/gunicorn.conf.py
@@ -1,6 +1,7 @@
 import multiprocessing
 
 accesslog = "-"
+protocol = "uwsgi"
 bind = "unix:/run/gunicorn/gunicorn.sock"
 workers = multiprocessing.cpu_count() * 2 + 1
 wsgi_app = "main:create_app()"

--- a/prod/nginx/templates/default.conf.template
+++ b/prod/nginx/templates/default.conf.template
@@ -60,6 +60,10 @@ map $upstream_http_permissions_policy $pp {
     '' "accelerometer=(), camera=(), browsing-topics=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()";
 }
 
+upstream app_backend {
+    server unix:/run/gunicorn/gunicorn.sock;
+}
+
 server {
     listen 443 quic reuseport;
     listen 443 ssl;
@@ -85,33 +89,30 @@ server {
     add_header Cross-Origin-Resource-Policy $corp always;
     add_header Cross-Origin-Embedder-Policy $coep always;
     add_header Permissions-Policy $pp always;
-    proxy_hide_header  __No-Implicit-COEP;
+    uwsgi_hide_header __No-Implicit-COEP;
 
     location / {
-        proxy_pass http://unix:/run/gunicorn/gunicorn.sock;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_set_header X-Forwarded-Host $host;
-        proxy_set_header X-Forwarded-Prefix /;
+        uwsgi_pass app_backend;
+        include uwsgi_params;
 
         location /addpart {
             # In theory users can upload up to 10 * 20 MiB + image (5 MiB) + the request itself (a few kB), so 206 MiB should be enough
             # in case of chaning this value modify location part edit too
             client_max_body_size 206M;
-            # proxy_pass is not inherited
-            proxy_pass http://unix:/run/gunicorn/gunicorn.sock;
+            # uwsgi_pass is not inherited
+            uwsgi_pass app_backend;
         }
 
         location ~ ^/part:\d+/edit$ {
             # 206M as in /addpart
             client_max_body_size 206M;
-            # proxy_pass is not inherited
-            proxy_pass http://unix:/run/gunicorn/gunicorn.sock;
+            # uwsgi_pass is not inherited
+            uwsgi_pass app_backend;
         }
 
         location /accountsettings {
             client_max_body_size 6M;
-            proxy_pass http://unix:/run/gunicorn/gunicorn.sock;
+            uwsgi_pass app_backend;
         }
     }
 

--- a/prod/uwsgi_params
+++ b/prod/uwsgi_params
@@ -1,0 +1,16 @@
+uwsgi_param  QUERY_STRING       $query_string;
+uwsgi_param  REQUEST_METHOD     $request_method;
+uwsgi_param  CONTENT_TYPE       $content_type;
+uwsgi_param  CONTENT_LENGTH     $content_length;
+
+uwsgi_param  REQUEST_URI        $request_uri;
+uwsgi_param  PATH_INFO          $document_uri;
+uwsgi_param  DOCUMENT_ROOT      $document_root;
+uwsgi_param  SERVER_PROTOCOL    $server_protocol;
+uwsgi_param  REQUEST_SCHEME     $scheme;
+uwsgi_param  HTTPS              $https if_not_empty;
+
+uwsgi_param  REMOTE_ADDR        $remote_addr;
+uwsgi_param  REMOTE_PORT        $remote_port;
+uwsgi_param  SERVER_PORT        $server_port;
+uwsgi_param  SERVER_NAME        $server_name;

--- a/website/__init__.py
+++ b/website/__init__.py
@@ -11,7 +11,6 @@ from flask_seasurf import SeaSurf
 from flask_sqlalchemy import SQLAlchemy
 from flask_talisman import Talisman
 from sqlalchemy.orm import DeclarativeBase, MappedAsDataclass
-from werkzeug.middleware.proxy_fix import ProxyFix
 
 from .secrets_manager import *
 from .utils import extend_talisman_csp
@@ -81,10 +80,6 @@ def create_app() -> Flask:
     app.config["MAILERLITE_API_KEY"] = MAILERLITE_API_KEY
     if production:
         app.config["SERVER_NAME"] = getenv("DOMAIN", "orp.testing")
-
-    if getenv("TRUSTED_PROXIES", "0") == "1":
-        # This assignment is correct. See https://flask.palletsprojects.com/en/2.3.x/deploying/proxy_fix/
-        app.wsgi_app = ProxyFix(app.wsgi_app, x_for=1, x_proto=1, x_host=1, x_prefix=1)  # type: ignore[method-assign]
 
     app.config["SQLALCHEMY_DATABASE_URI"] = (
         f'mysql://root:rootroot@{getenv("DB_HOST", "127.0.0.1")}:3306/orp_db'


### PR DESCRIPTION
TODO:

- [x] check if remote address is passed properly
  - **it isn't**, I guess we'll have to keep using HTTP for now
- [x] rebase after #53 is merged
- [x] consider integrating certificate renewal using the [native ACME protocol integration](https://blog.nginx.org/blog/native-support-for-acme-protocol)
  - **NOT NOW**
  - we're switching to nginx running on host, but the distro does not package the ACME module and I don't plan on building it on host (it's easier to do as a Docker image, because then I can easily guarantee that the module will always be built when nginx version changes)
- [ ] #56 