### PR TITLE
Mount uploads directly and overwrite other static files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,4 +68,4 @@ COPY --from=theme /theme/node_modules/bootstrap/dist/js/bootstrap.bundle.min.js 
 RUN find website/static/ -type f -not -empty -exec sh -c "gzip -c -9 {} > {}.gz" \;
 
 # overwrite static files in host's website/static/ (mounted as /shared-static), migrate db and start the app
-CMD [ "/bin/sh", "-c", "cp -a website/static/. /shared-static/ && flask db upgrade && gunicorn" ]
+CMD [ "/bin/sh", "-c", "for d in 'assets' 'css' 'fa' 'js'; do cp -a \"website/static/$d\" /shared-static/.; done && flask db upgrade && gunicorn" ]

--- a/compose.yaml
+++ b/compose.yaml
@@ -70,9 +70,9 @@ services:
       TRUSTED_PROXIES: "1"
       FLASK_ENV: "production"
     volumes:
-      - ./website/static/uploads:/app/website/static/uploads
       - /run/gunicorn:/run/gunicorn
       - ./website/static:/shared-static
+      - ./website/static/uploads:/app/website/static/uploads
     profiles:
       - prod
 


### PR DESCRIPTION
Fixes problems caused by #56.

Uploads are now mounted directly from host directory. Built static files (skipping uploads) are copied from container's local static directory to one mounted from host.

With this nginx can serve directly from host and see up-to-date static files (both uploads and theme/scripts/etc.).